### PR TITLE
Corrigindo a responsividade da pagina de login

### DIFF
--- a/src/Nodus.Elluris.Mvc/Areas/Identity/Pages/Account/Login.cshtml
+++ b/src/Nodus.Elluris.Mvc/Areas/Identity/Pages/Account/Login.cshtml
@@ -49,7 +49,7 @@
     <div class="col-md-6 col-md-offset-2">
         <section>
             <div class="signup-image">
-                <figure><img src="~/images/signup-image.jpg" alt="Imagem Login" class="rounded" height="400" width="600"></figure>
+                <figure><img src="~/images/signup-image.jpg" alt="Imagem Login" class="rounded img-fluid"></figure>
             </div>
         </section>
     </div>


### PR DESCRIPTION
A pagina não estava responsiva pois o tamanho da imagem estava definido de forma fixa no HTML.
Foi adicionado uma propriedade do bootstrap para realizar esta correção.